### PR TITLE
Page post image

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -1,5 +1,11 @@
 {% if post.header.teaser %}
   {% capture teaser %}{{ post.header.teaser }}{% endcapture %}
+{% elsif post.teaser_image %}
+  {% capture teaser %}{{ post.teaser_image }}{% endcapture %}
+{% elsif post.header.image %}
+  {% capture teaser %}{{ post.header.image }}{% endcapture %}
+{% elsif post.image %}
+  {% capture teaser %}{{ post.image }}{% endcapture %}
 {% else %}
   {% assign teaser = site.teaser %}
 {% endif %}

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -42,8 +42,10 @@
         {% endfor %}
       {% endif %}
     </div>
-  {% else %}
+  {% elsif page.header.image %}
     <img src="{{ page.header.image | relative_url }}" alt="{{ image_description }}" class="page__hero-image">
+  {% else %}
+    <img src="{{ page.image | relative_url }}" alt="{{ image_description }}" class="page__hero-image">
   {% endif %}
   {% if page.header.caption %}
     <span class="page__hero-caption">{{ page.header.caption | markdownify | remove: "<p>" | remove: "</p>" }}</span>

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -32,10 +32,10 @@
   {%- assign author_twitter = author.twitter | replace: "@", "" -%}
 {%- endif -%}
 
-{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image | absolute_url -%}
+{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image | page.image | absolute_url -%}
 {%- assign page_large_image = page_large_image | escape -%}
 
-{%- assign page_teaser_image = page.header.teaser | default: site.og_image | absolute_url -%}
+{%- assign page_teaser_image = page.header.teaser | default: page.teaser_image | default: site.og_image | default: site.logo | absolute_url -%}
 {%- assign page_teaser_image = page_teaser_image | escape -%}
 
 {%- assign site_og_image = site.og_image | absolute_url -%}

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -32,7 +32,7 @@
   {%- assign author_twitter = author.twitter | replace: "@", "" -%}
 {%- endif -%}
 
-{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image | page.image | absolute_url -%}
+{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image | default: page.image | absolute_url -%}
 {%- assign page_large_image = page_large_image | escape -%}
 
 {%- assign page_teaser_image = page.header.teaser | default: page.teaser_image | default: site.og_image | default: site.logo | absolute_url -%}

--- a/_layouts/archive-taxonomy.html
+++ b/_layouts/archive-taxonomy.html
@@ -3,7 +3,7 @@ layout: default
 author_profile: false
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image or page.image %}
   {% include page__hero.html %}
 {% elsif page.header.video.id and page.header.video.provider %}
   {% include page__hero_video.html %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image or page.image %}
   {% include page__hero.html %}
 {% elsif page.header.video.id and page.header.video.provider %}
   {% include page__hero_video.html %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image or page.image %}
   {% include page__hero.html %}
 {% endif %}
 

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image or page.image %}
   {% include page__hero.html %}
 {% elsif page.header.video.id and page.header.video.provider %}
   {% include page__hero_video.html %}

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image or page.image %}
   {% include page__hero.html %}
 {% elsif page.header.video.id and page.header.video.provider %}
   {% include page__hero_video.html %}

--- a/test/_posts/2020-11-11-layout-image.md
+++ b/test/_posts/2020-11-11-layout-image.md
@@ -1,0 +1,17 @@
+---
+title: "Layout: Image"
+image: "https://picsum.photos/1024/768"
+categories:
+  - Layout
+  - Uncategorized
+tags:
+  - image
+  - layout
+---
+
+This post should display an **image**.
+
+Set image using frontmatter like this:
+```
+image: "https://picsum.photos/1024/768"
+```

--- a/test/_posts/2020-11-11-layout-teaser_image.md
+++ b/test/_posts/2020-11-11-layout-teaser_image.md
@@ -1,0 +1,19 @@
+---
+title: "Layout: Teaser Image"
+teaser_image: "https://picsum.photos/600/400"
+categories:
+  - Layout
+  - Uncategorized
+tags:
+  - image
+  - layout
+---
+
+This post should have a **teaser image**.
+Please check page source & make sure teaser image
+included as `og:image` and twitter image.
+
+Set teaser image using frontmatter like this:
+```
+teaser_image: "https://picsum.photos/1024/768"
+```


### PR DESCRIPTION
 Use post/page image & teaser_image if exist

Use image because it also used by jekyll-seo-tag
to set OG image, Twitter image, & JSON-LD image

Use teaser_image just to make it easier to setup
client side CMS (netlify cms, forestry, etc)